### PR TITLE
Add support for AWS Bedrock Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,23 @@ module "cognito_pool" {
 }
 ```
 
+### Bedrock Guardrail Module
+
+To provision the Bedrock Guardrail and related resources, include the following module configuration:
+
+```hcl
+module "bedrock_guardrail" {
+  source                 = "../modules/bedrock_guardrail"
+  guardrail_enabled      = var.bedrock_guardrail_enabled
+  guardrail_name         = var.bedrock_guardrail_name
+  guardrail_description  = var.bedrock_guardrail_description
+  blocked_input_messaging  = var.bedrock_blocked_input_messaging
+  blocked_outputs_messaging = var.bedrock_blocked_outputs_messaging
+  topics                 = var.bedrock_topics
+}
+```
+
+
 ## Variables
 
 Each module has specific input variables that you need to provide. Refer to the respective module's variables file for the full list of required and optional variables.

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -85,6 +85,28 @@ module "ecs" {
   alb_sg_id                        = ["${module.load_balancer.alb_sg_id}"]
 }
 
+
+module "bedrock_guardrail" {
+  source                 = "../modules/bedrock_guardrail"
+  guardrail_enabled      = var.bedrock_guardrail_enabled
+  guardrail_name         = var.bedrock_guardrail_name
+  guardrail_description  = var.bedrock_guardrail_description
+  blocked_input_messaging  = var.bedrock_blocked_input_messaging
+  blocked_outputs_messaging = var.bedrock_blocked_outputs_messaging
+  topics                 = var.bedrock_topics
+}
+
+# Accessing the outputs from the Guardrail module
+output "guardrail_arn" {
+  description = "ARN of the Bedrock Guardrail"
+  value       = module.bedrock_guardrail.guardrail_arn
+}
+
+output "guardrail_name" {
+  description = "The name of the Bedrock Guardrail."
+  value       = module.bedrock_guardrail.guardrail_name
+}
+
 # load_balancer/outputs.tf
 
 output "vpc_id" {

--- a/dev/provider.tf
+++ b/dev/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.15.0"
+      version = "~> 5.63.0"
     }
   }
   required_version = ">= 0.14.0"

--- a/dev/terraform.tfvars_sample
+++ b/dev/terraform.tfvars_sample
@@ -1,5 +1,24 @@
 # terraform.tfvars
 
+# Bedrock Guardrail Vars
+bedrock_guardrail_enabled = false
+bedrock_guardrail_name = "bedrock_guardrail_name"
+bedrock_guardrail_description = "Guardrail description"
+
+bedrock_blocked_input_messaging = "Your request was blocked due to platform policy."
+bedrock_blocked_outputs_messaging = "The model's response was blocked due to platform policy."
+
+
+
+bedrock_topics = [
+  {
+    name       = "investment_topic"
+    examples   = ["Where should I invest my money ?"]
+    type       = "DENY"
+    definition = "Investment advice refers to inquiries, guidance, or recommendations regarding the management or allocation of funds or assets with the goal of generating returns."
+  }
+]
+
 # Load Balancer Vars
 public_subnet_cidrs     = ["172.1.0.0/23", "172.1.2.0/23"]
 private_subnet_cidrs    = ["172.1.4.0/23", "172.1.8.0/23"]

--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -1,3 +1,42 @@
+#Bedrock Guardrail Variables
+
+variable "bedrock_guardrail_enabled" {
+  description = "Enable or disable the Bedrock Guardrail module"
+  type        = bool
+  default     = false
+}
+
+variable "bedrock_guardrail_name" {
+  description = "Name for the Bedrock Guardrail"
+  type        = string
+}
+
+variable "bedrock_guardrail_description" {
+  description = "Description for the Bedrock Guardrail resource"
+  type        = string
+}
+
+variable "bedrock_blocked_input_messaging" {
+  description = "Message to return when the guardrail blocks a prompt (input)"
+  type        = string
+}
+
+variable "bedrock_blocked_outputs_messaging" {
+  description = "Message to return when the guardrail blocks a model response (output)"
+  type        = string
+}
+
+variable "bedrock_topics" {
+  description = "List of topics to block, each as an object with name, examples, type, and definition"
+  type = list(object({
+    name       = string
+    examples   = list(string)
+    type       = string
+    definition = string
+  }))
+  default     = []
+}
+
 #ECR Variables
 
 variable "ecr_repo_name" {

--- a/modules/bedrock_guardrail/bedrock_guardrail.tf
+++ b/modules/bedrock_guardrail/bedrock_guardrail.tf
@@ -1,0 +1,23 @@
+resource "aws_bedrock_guardrail" "bedrock_guardrail" {
+  count       = var.guardrail_enabled ? 1 : 0
+  name        = var.guardrail_name
+  description = var.guardrail_description
+
+  blocked_input_messaging  = var.blocked_input_messaging
+  blocked_outputs_messaging = var.blocked_outputs_messaging
+
+  dynamic "topic_policy_config" {
+    for_each = length(var.topics) > 0 ? [1] : []
+    content {
+      dynamic "topics_config" {
+        for_each = var.topics
+        content {
+          name       = topics_config.value.name
+          examples   = topics_config.value.examples
+          type       = topics_config.value.type
+          definition = topics_config.value.definition
+        }
+      }
+    }
+  }
+}

--- a/modules/bedrock_guardrail/outputs.tf
+++ b/modules/bedrock_guardrail/outputs.tf
@@ -1,0 +1,9 @@
+output "guardrail_arn" {
+  description = "ARN of the Bedrock Guardrail"
+  value       = aws_bedrock_guardrail.bedrock_guardrail[0].guardrail_arn
+}
+
+output "guardrail_name" {
+  description = "The name of the Bedrock Guardrail."
+  value       = var.guardrail_name
+}

--- a/modules/bedrock_guardrail/variables.tf
+++ b/modules/bedrock_guardrail/variables.tf
@@ -1,0 +1,41 @@
+variable "guardrail_enabled" {
+  description = "Enable or disable the Bedrock Guardrail resource"
+  type        = bool
+  default     = false
+}
+
+variable "guardrail_name" {
+  description = "Name for the Bedrock Guardrail"
+  type        = string
+}
+
+variable "guardrail_description" {
+  description = "Description for the Bedrock Guardrail resource"
+  type        = string
+  default     = "Amplify's Bedrock Guardrail description"
+}
+
+variable "blocked_input_messaging" {
+  description = "Message to return when the guardrail blocks a prompt (input)"
+  type        = string
+  default     = "Your request was blocked due to policy restrictions."
+}
+
+variable "blocked_outputs_messaging" {
+  description = "Message to return when the guardrail blocks a model response (output)"
+  type        = string
+  default     = "The model's response was blocked due to policy restrictions."
+}
+
+
+
+variable "topics" {
+  description = "List of topics to block, each as an object with name, examples, type, and definition"
+  type = list(object({
+    name       = string
+    examples   = list(string)
+    type       = string
+    definition = string
+  }))
+  default = []
+}

--- a/prod/main.tf
+++ b/prod/main.tf
@@ -85,6 +85,28 @@ module "ecs" {
   alb_sg_id                        = ["${module.load_balancer.alb_sg_id}"]
 }
 
+
+module "bedrock_guardrail" {
+  source                 = "../modules/bedrock_guardrail"
+  guardrail_enabled      = var.bedrock_guardrail_enabled
+  guardrail_name         = var.bedrock_guardrail_name
+  guardrail_description  = var.bedrock_guardrail_description
+  blocked_input_messaging  = var.bedrock_blocked_input_messaging
+  blocked_outputs_messaging = var.bedrock_blocked_outputs_messaging
+  topics                 = var.bedrock_topics
+}
+
+# Accessing the outputs from the Guardrail module
+output "guardrail_arn" {
+  description = "ARN of the Bedrock Guardrail"
+  value       = module.bedrock_guardrail.guardrail_arn
+}
+
+output "guardrail_name" {
+  description = "The name of the Bedrock Guardrail."
+  value       = module.bedrock_guardrail.guardrail_name
+}
+
 # load_balancer/outputs.tf
 
 output "vpc_id" {

--- a/prod/provider.tf
+++ b/prod/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.15.0"
+      version = "~> 5.63.0"
     }
   }
   required_version = ">= 0.14.0"

--- a/prod/terraform.tfvars_sample
+++ b/prod/terraform.tfvars_sample
@@ -1,5 +1,24 @@
 # terraform.tfvars
 
+# Bedrock Guardrail Vars
+bedrock_guardrail_enabled = false
+bedrock_guardrail_name = "bedrock_guardrail_name"
+bedrock_guardrail_description = "Guardrail description"
+
+bedrock_blocked_input_messaging = "Your request was blocked due to platform policy."
+bedrock_blocked_outputs_messaging = "The model's response was blocked due to platform policy."
+
+
+
+bedrock_topics = [
+  {
+    name       = "investment_topic"
+    examples   = ["Where should I invest my money ?"]
+    type       = "DENY"
+    definition = "Investment advice refers to inquiries, guidance, or recommendations regarding the management or allocation of funds or assets with the goal of generating returns."
+  }
+]
+
 # Load Balancer Vars
 public_subnet_cidrs     = ["172.1.0.0/23", "172.1.2.0/23"]
 private_subnet_cidrs    = ["172.1.4.0/23", "172.1.8.0/23"]

--- a/prod/variables.tf
+++ b/prod/variables.tf
@@ -1,3 +1,42 @@
+#Bedrock Guardrail Variables
+
+variable "bedrock_guardrail_enabled" {
+  description = "Enable or disable the Bedrock Guardrail module"
+  type        = bool
+  default     = false
+}
+
+variable "bedrock_guardrail_name" {
+  description = "Name for the Bedrock Guardrail"
+  type        = string
+}
+
+variable "bedrock_guardrail_description" {
+  description = "Description for the Bedrock Guardrail resource"
+  type        = string
+}
+
+variable "bedrock_blocked_input_messaging" {
+  description = "Message to return when the guardrail blocks a prompt (input)"
+  type        = string
+}
+
+variable "bedrock_blocked_outputs_messaging" {
+  description = "Message to return when the guardrail blocks a model response (output)"
+  type        = string
+}
+
+variable "bedrock_topics" {
+  description = "List of topics to block, each as an object with name, examples, type, and definition"
+  type = list(object({
+    name       = string
+    examples   = list(string)
+    type       = string
+    definition = string
+  }))
+  default     = []
+}
+
 #ECR Variables
 
 variable "ecr_repo_name" {


### PR DESCRIPTION
This PR introduces support for AWS Bedrock Guardrails to enforce content policies on AI model interactions, enhancing platform safety and compliance.

### **Important: Provider Update**

To support the `aws_bedrock_guardrail` resource, the required AWS provider version has been updated. When applying this change to an existing, previously initialized environment (e.g., production), you must run `terraform init -upgrade` to force the download of the new provider. For brand new environments, a standard `terraform init` will work as usual.

### **Implementation Details**

- A new Terraform module, bedrock_guardrail, has been created to provision the guardrail resource.