### PR TITLE
Added protocol info to output of Cognito URL

### DIFF
--- a/dev/main.tf
+++ b/dev/main.tf
@@ -123,7 +123,7 @@ output "user_pool_domain" {
 }
 
 output "cognito_user_pool_url" {
-  value = module.cognito_pool.cognito_user_pool_url
+  value = "https://${module.cognito_pool.cognito_user_pool_url}"
 }
 
 output "cognito_user_pool_client_id" {

--- a/modules/load_balancer/load_balancer.tf
+++ b/modules/load_balancer/load_balancer.tf
@@ -412,7 +412,7 @@ resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.alb.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-PQ-2025-09"
   certificate_arn   = aws_acm_certificate.ssl_cert[0].arn
   default_action {
     type = "fixed-response"
@@ -430,7 +430,7 @@ resource "aws_lb_listener" "https_root_redirect" {
   load_balancer_arn = aws_lb.alb.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-PQ-2025-09"
   certificate_arn   = aws_acm_certificate.ssl_san_cert[0].arn
   default_action {
     type = "fixed-response"


### PR DESCRIPTION
This updates the outputs to include the protocol in the URL for Cognito, used in the OAUTH URL in backend deployment step.